### PR TITLE
Option to use multiple buffers

### DIFF
--- a/npm-common.el
+++ b/npm-common.el
@@ -29,6 +29,11 @@
 (require 'subr-x)
 (require 'transient)
 
+(defgroup npm ()
+  "Group for npm."
+  :group 'tools
+  :prefix "npm-")
+
 (defconst npm-common--config-file "package.json")
 
 ;; Common


### PR DESCRIPTION
Hi! Thanks for your maintenance of great package!

Some `npm` commands, like commands which serve http server, hold `*npm*` buffer continuously. So I add option to use multiple buffers.
By default, just use `*npm*` as buffer name. When `npm-common-buffer-name-function` is set to `npm-common-create-unique-buffer-name`, created buffer name is unique to each root and each npm command, like `*npm run dev in /path/to/root/*`.

Thanks!