### PR TITLE
npm install without package arguments?

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - 25.3
           - 26.3
           - 27.1
+          - 28.1
+          - 29.4
     steps:
       - uses: actions/checkout@v2
       - uses: purcell/setup-emacs@master

--- a/npm-install.el
+++ b/npm-install.el
@@ -36,7 +36,8 @@
      ("-o" "Save as optional dependency"        "--save-optional")
      ("-n" "Do not save to package.json"        "--no-save")]
     [["Command"
-      ("i" "Install"       npm-install)]]
+      ("i" "Install"       npm-install)
+	  ("I" "Install currently required packages only" npm-install-current)]]
   (interactive)
   (transient-setup 'npm-install-menu))
 
@@ -56,6 +57,12 @@
   "Arguments function for transient."
   (transient-args 'npm-install-menu))
 
+(defun npm-install-current (&optional args)
+  "Invoke the compile mode with the install prefix-command and ARGS if provided but no packages"
+  (interactive)
+  (let ((arguments (string-join args " "))
+		(npm-command (npm-install--get-install-command "")))
+	(npm-common--compile npm-command arguments)))
 
 ;;;###autoload
 (defun npm-install (&optional args)

--- a/npm-install.el
+++ b/npm-install.el
@@ -61,8 +61,8 @@
   "Invoke the compile mode with the install prefix-command and ARGS if provided but no packages"
   (interactive)
   (let ((arguments (string-join args " "))
-		(npm-command (npm-install--get-install-command "")))
-	(npm-common--compile npm-command arguments)))
+	      (npm-command (npm-install--get-install-command "")))
+    (npm-common--compile npm-command arguments)))
 
 ;;;###autoload
 (defun npm-install (&optional args)

--- a/npm-install.el
+++ b/npm-install.el
@@ -36,8 +36,8 @@
      ("-o" "Save as optional dependency"        "--save-optional")
      ("-n" "Do not save to package.json"        "--no-save")]
     [["Command"
-      ("i" "Install"       npm-install)
-      ("I" "Install currently required packages only" npm-install-current)]]
+    ("i" "Install new package"       npm-install)
+    ("I" "Install current packages (in package.json)" npm-install-current)]]
   (interactive)
   (transient-setup 'npm-install-menu))
 
@@ -58,7 +58,7 @@
   (transient-args 'npm-install-menu))
 
 (defun npm-install-current (&optional args)
-  "Invoke the compile mode with the install prefix-command and ARGS if provided but no packages"
+  "Invoke the compile mode with the install prefix-command and ARGS if provided but no packages."
   (interactive)
   (let ((arguments (string-join args " "))
 	      (npm-command (npm-install--get-install-command "")))

--- a/npm-install.el
+++ b/npm-install.el
@@ -37,7 +37,7 @@
      ("-n" "Do not save to package.json"        "--no-save")]
     [["Command"
       ("i" "Install"       npm-install)
-	  ("I" "Install currently required packages only" npm-install-current)]]
+      ("I" "Install currently required packages only" npm-install-current)]]
   (interactive)
   (transient-setup 'npm-install-menu))
 

--- a/npm.el
+++ b/npm.el
@@ -4,7 +4,7 @@
 
 ;; Author: Shane Kennedy
 ;; Homepage: https://github.com/shaneikennedy/npm.el
-;; Package-Requires: ((emacs "25.1") (transient "0.1.0") (jest "20200625"))
+;; Package-Requires: ((emacs "25.1") (transient "0.1.0") (jest "20220807.2243"))
 ;; Keywords: tools
 ;; Version: 0
 


### PR DESCRIPTION
I often find myself wanting to run npm install without arguments.  I don't think I'm able to do that (maybe I am and I'm not sure how?  I could have missed something).  This allows such an operation.

I'm happy to make changes as suggested.